### PR TITLE
Workflow improvements and Docker Compose integration

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -23,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.revision }}
     steps:
+      - name: Docker Setup Compose
+        uses: docker/setup-compose-action@v1.2.0
+        with:
+          version: latest
+
       - name: Checkout Source
         uses: actions/checkout@v5
 
@@ -35,6 +40,9 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           cache: maven
+
+      - name: Run Docker Compose
+        run: docker compose -f "docker/test-services.yml" up -d
 
       - name: Publish package
         run: mvn
@@ -51,3 +59,7 @@ jobs:
           SIGN_KEY_ID: ${{ secrets.OSS_SIGNING_KEY_ID_LONG }}
           SIGN_KEY: ${{ secrets.OSS_SIGNING_KEY }}
           SIGN_KEY_PASS: ${{ secrets.OSS_SIGNING_PASSWORD }}
+
+      - name: Stop Docker Compose
+        if: always()
+        run: docker compose -f "docker/test-services.yml" down

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       revision:
-        description: 'The version to publish for Spring Boot 3+ and JDK 17+'
+        description: 'The version to publish for Spring Data Redis 3.x and JDK 17+'
         required: true
         default: '2.0.0-SNAPSHOT'
 


### PR DESCRIPTION
This pull request updates the `.github/workflows/maven-publish.yml` workflow to improve the publishing process for Spring Data Redis 3.x projects and to integrate Docker Compose for managing test services during the build. The main changes focus on updating workflow descriptions and adding steps to set up, run, and clean up Docker Compose services.

Workflow improvements and Docker Compose integration:

* Updated the workflow input description to clarify that it targets Spring Data Redis 3.x and JDK 17+ instead of Spring Boot 3+.
* Added a step to set up Docker Compose using the `docker/setup-compose-action@v1.2.0` GitHub Action.
* Added a step to start test services using Docker Compose before publishing the package (`docker compose -f "docker/test-services.yml" up -d`).
* Added a cleanup step to always stop Docker Compose services after the workflow completes (`docker compose -f "docker/test-services.yml" down`).