### PR TITLE
Update Maven publish workflow with Docker Compose steps

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       revision:
-        description: 'The version to publish for Spring Data Redis 2.0.x - 2.7.x'
+        description: 'The version to publish for Spring Data Redis 2.1.x - 2.7.x'
         required: true
         default: '1.0.0-SNAPSHOT'
 
@@ -23,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.revision }}
     steps:
+      - name: Docker Setup Compose
+        uses: docker/setup-compose-action@v1.2.0
+        with:
+          version: latest
+
       - name: Checkout Source
         uses: actions/checkout@v5
 
@@ -35,6 +40,9 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           cache: maven
+
+      - name: Run Docker Compose
+        run: docker compose -f "docker/test-services.yml" up -d
 
       - name: Publish package
         run: mvn
@@ -51,3 +59,7 @@ jobs:
           SIGN_KEY_ID: ${{ secrets.OSS_SIGNING_KEY_ID_LONG }}
           SIGN_KEY: ${{ secrets.OSS_SIGNING_KEY }}
           SIGN_KEY_PASS: ${{ secrets.OSS_SIGNING_PASSWORD }}
+
+      - name: Stop Docker Compose
+        if: always()
+        run: docker compose -f "docker/test-services.yml" down


### PR DESCRIPTION
Adds Docker Compose setup, start, and stop steps to the Maven publish GitHub Actions workflow. Also updates the revision input description to reflect supported Spring Data Redis versions (2.1.x - 2.7.x).