### PR TITLE
Enhance test robustness and improve Redis configuration logging

### DIFF
--- a/microsphere-redis-replicator-spring/src/main/java/io/microsphere/redis/replicator/spring/config/RedisReplicatorConfiguration.java
+++ b/microsphere-redis-replicator-spring/src/main/java/io/microsphere/redis/replicator/spring/config/RedisReplicatorConfiguration.java
@@ -37,6 +37,7 @@ import java.util.Set;
 
 import static io.microsphere.annotation.ConfigurationProperty.APPLICATION_SOURCE;
 import static io.microsphere.collection.Lists.ofList;
+import static io.microsphere.constants.PropertyConstants.ENABLED_PROPERTY_NAME;
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.redis.spring.util.RedisSpringUtils.getBoolean;
 import static java.lang.Boolean.parseBoolean;
@@ -71,7 +72,7 @@ public class RedisReplicatorConfiguration implements ApplicationListener<RedisCo
             defaultValue = DEFAULT_ENABLED_PROPERTY_VALUE,
             source = APPLICATION_SOURCE
     )
-    public static final String REDIS_REPLICATOR_ENABLED_PROPERTY_NAME = REDIS_REPLICATOR_PROPERTY_NAME_PREFIX + "enabled";
+    public static final String REDIS_REPLICATOR_ENABLED_PROPERTY_NAME = REDIS_REPLICATOR_PROPERTY_NAME_PREFIX + ENABLED_PROPERTY_NAME;
 
     public static final String REDIS_REPLICATOR_CONSUMER_PROPERTY_NAME_PREFIX = REDIS_REPLICATOR_PROPERTY_NAME_PREFIX + "consumer.";
 
@@ -87,7 +88,7 @@ public class RedisReplicatorConfiguration implements ApplicationListener<RedisCo
             defaultValue = DEFAULT_REDIS_REPLICATOR_CONSUMER_ENABLED_PROPERTY_VALUE,
             source = APPLICATION_SOURCE
     )
-    public static final String REDIS_REPLICATOR_CONSUMER_ENABLED_PROPERTY_NAME = REDIS_REPLICATOR_CONSUMER_PROPERTY_NAME_PREFIX + "enabled";
+    public static final String REDIS_REPLICATOR_CONSUMER_ENABLED_PROPERTY_NAME = REDIS_REPLICATOR_CONSUMER_PROPERTY_NAME_PREFIX + ENABLED_PROPERTY_NAME;
 
     public static final String REDIS_REPLICATOR_DEFAULT_DOMAIN = "default";
 
@@ -232,11 +233,11 @@ public class RedisReplicatorConfiguration implements ApplicationListener<RedisCo
     }
 
     public static boolean isRedisReplicatorEnabled(Environment environment) {
-        return getBoolean(environment, REDIS_REPLICATOR_ENABLED_PROPERTY_NAME, DEFAULT_ENABLED, "Replicator", "enabled");
+        return getBoolean(environment, REDIS_REPLICATOR_ENABLED_PROPERTY_NAME, DEFAULT_ENABLED, "Replicator", ENABLED_PROPERTY_NAME);
     }
 
     public static boolean isRedisReplicatorConsumerEnabled(Environment environment) {
-        return getBoolean(environment, REDIS_REPLICATOR_CONSUMER_ENABLED_PROPERTY_NAME, DEFAULT_REDIS_REPLICATOR_CONSUMER_ENABLED, "Replicator Consumer", "enabled");
+        return getBoolean(environment, REDIS_REPLICATOR_CONSUMER_ENABLED_PROPERTY_NAME, DEFAULT_REDIS_REPLICATOR_CONSUMER_ENABLED, "Replicator Consumer", ENABLED_PROPERTY_NAME);
     }
 
     public static RedisReplicatorConfiguration get(BeanFactory beanFactory) {

--- a/microsphere-redis-replicator-spring/src/main/java/io/microsphere/redis/replicator/spring/kafka/KafkaRedisReplicatorConfiguration.java
+++ b/microsphere-redis-replicator-spring/src/main/java/io/microsphere/redis/replicator/spring/kafka/KafkaRedisReplicatorConfiguration.java
@@ -139,5 +139,6 @@ public class KafkaRedisReplicatorConfiguration implements EnvironmentAware, Init
 
     @Override
     public void destroy() throws Exception {
+        this.logger.trace("The KafkaRedisReplicatorConfiguration is destroying...");
     }
 }

--- a/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/kafka/producer/KafkaProducerRedisReplicatorConfigurationTest.java
+++ b/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/kafka/producer/KafkaProducerRedisReplicatorConfigurationTest.java
@@ -27,6 +27,7 @@ import static io.microsphere.redis.replicator.spring.kafka.producer.KafkaProduce
 import static io.microsphere.redis.replicator.spring.kafka.producer.KafkaProducerRedisReplicatorConfiguration.KAFKA_PRODUCER_KEY_PREFIX_PROPERTY_NAME;
 import static io.microsphere.redis.replicator.spring.kafka.producer.KafkaProducerRedisReplicatorConfiguration.KAFKA_PRODUCER_PROPERTY_NAME_PREFIX;
 import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -65,8 +66,10 @@ class KafkaProducerRedisReplicatorConfigurationTest {
     }
 
     @Test
-    void testDestroyOnNotInitialized() throws Exception {
-        KafkaProducerRedisReplicatorConfiguration configuration = new KafkaProducerRedisReplicatorConfiguration();
-        configuration.destroy();
+    void testDestroyOnNotInitialized() {
+        assertDoesNotThrow(() -> {
+            KafkaProducerRedisReplicatorConfiguration configuration = new KafkaProducerRedisReplicatorConfiguration();
+            configuration.destroy();
+        });
     }
 }

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/interceptor/RedisMethodInterceptorTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/interceptor/RedisMethodInterceptorTest.java
@@ -33,6 +33,7 @@ import org.springframework.test.context.ContextConfiguration;
 import java.lang.reflect.Method;
 
 import static io.microsphere.redis.spring.context.RedisContext.BEAN_NAME;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * {@link RedisMethodInterceptor} Test
@@ -73,18 +74,18 @@ class RedisMethodInterceptorTest extends AbstractRedisTest {
     }
 
     @Test
-    void testBeforeExecute() throws Throwable {
-        this.interceptor.beforeExecute(this.context);
+    void testBeforeExecute() {
+        assertDoesNotThrow(() -> this.interceptor.beforeExecute(this.context));
     }
 
     @Test
-    void testAfterExecute() throws Throwable {
-        this.interceptor.afterExecute(this.context, null, null);
+    void testAfterExecute() {
+        assertDoesNotThrow(() -> this.interceptor.afterExecute(this.context, null, null));
     }
 
     @Test
     void testHandleError() {
-        this.interceptor.handleError(this.context, true, null, null, null);
+        assertDoesNotThrow(() -> this.interceptor.handleError(this.context, true, null, null, null));
     }
 
     static class RedisMethodInterceptorImpl implements RedisMethodInterceptor {

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/metadata/SpringRedisMetadataLoaderTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/metadata/SpringRedisMetadataLoaderTest.java
@@ -39,6 +39,7 @@ import static io.microsphere.redis.util.RedisCommandUtils.getRedisCommands;
 import static io.microsphere.redis.util.RedisCommandUtils.getRedisWriteCommands;
 import static io.microsphere.text.FormatUtils.format;
 import static java.util.Locale.ENGLISH;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -83,43 +84,45 @@ class SpringRedisMetadataLoaderTest {
 
     @Test
     void testUnknown() {
-        Method[] methods = RedisCommands.class.getMethods();
-        Set<String> redisCommands = getRedisCommands();
-        Set<String> redisWriteCommands = getRedisWriteCommands();
-        StringBuilder supported = new StringBuilder();
-        StringBuilder unsupported = new StringBuilder();
+        assertDoesNotThrow(() -> {
+            Method[] methods = RedisCommands.class.getMethods();
+            Set<String> redisCommands = getRedisCommands();
+            Set<String> redisWriteCommands = getRedisWriteCommands();
+            StringBuilder supported = new StringBuilder();
+            StringBuilder unsupported = new StringBuilder();
 
-        Set<String> supportedCommands = new HashSet<>();
-        Set<String> unsupportedCommands = new HashSet<>(redisCommands);
+            Set<String> supportedCommands = new HashSet<>();
+            Set<String> unsupportedCommands = new HashSet<>(redisCommands);
 
-        Set<Method> supportedMethods = new HashSet<>(ofList(methods));
-        Set<Method> unsupportedMethods = new HashSet<>(ofList(methods));
+            Set<Method> supportedMethods = new HashSet<>(ofList(methods));
+            Set<Method> unsupportedMethods = new HashSet<>(ofList(methods));
 
-        for (Method method : methods) {
-            String name = method.getName().toUpperCase(ENGLISH);
-            if (redisCommands.contains(name)) {
-                unsupportedMethods.remove(method);
-            } else {
-                supportedMethods.remove(method);
+            for (Method method : methods) {
+                String name = method.getName().toUpperCase(ENGLISH);
+                if (redisCommands.contains(name)) {
+                    unsupportedMethods.remove(method);
+                } else {
+                    supportedMethods.remove(method);
+                }
             }
-        }
 
-        for (Method supportedMethod : supportedMethods) {
-            String command = supportedMethod.getName().toUpperCase(ENGLISH);
-            supported.append(LINE_SEPARATOR);
-            supported.append(format("{} , command : {} , default : {}", buildMethodId(supportedMethod), command,
-                    redisWriteCommands.contains(command),
-                    supportedMethod.isDefault()));
-            supportedCommands.add(command);
-            unsupportedCommands.remove(command);
-        }
+            for (Method supportedMethod : supportedMethods) {
+                String command = supportedMethod.getName().toUpperCase(ENGLISH);
+                supported.append(LINE_SEPARATOR);
+                supported.append(format("{} , command : {} , default : {}", buildMethodId(supportedMethod), command,
+                        redisWriteCommands.contains(command),
+                        supportedMethod.isDefault()));
+                supportedCommands.add(command);
+                unsupportedCommands.remove(command);
+            }
 
-        for (Method unsupportedMethod : unsupportedMethods) {
-            unsupported.append(LINE_SEPARATOR);
-            unsupported.append(format("{} , default : {}", buildMethodId(unsupportedMethod), unsupportedMethod.isDefault()));
-        }
+            for (Method unsupportedMethod : unsupportedMethods) {
+                unsupported.append(LINE_SEPARATOR);
+                unsupported.append(format("{} , default : {}", buildMethodId(unsupportedMethod), unsupportedMethod.isDefault()));
+            }
 
-        logger.trace("Supported Methods : {}", supported);
-        logger.trace("Unsupported Methods : {}", unsupported);
+            logger.trace("Supported Methods : {}", supported);
+            logger.trace("Unsupported Methods : {}", unsupported);
+        });
     }
 }

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/metadata/SpringRedisMetadataRepositoryTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/metadata/SpringRedisMetadataRepositoryTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.connection.RedisCommands;
 import org.springframework.data.redis.connection.RedisConnection;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -42,6 +43,7 @@ import static io.microsphere.redis.spring.metadata.SpringRedisMetadataRepository
 import static io.microsphere.redis.spring.metadata.SpringRedisMetadataRepository.getWriteCommandMethod;
 import static io.microsphere.redis.spring.metadata.SpringRedisMetadataRepository.getWriteParameterMetadataList;
 import static io.microsphere.redis.spring.metadata.SpringRedisMetadataRepository.init;
+import static io.microsphere.redis.spring.metadata.SpringRedisMetadataRepository.initRedisConnectionInterface;
 import static io.microsphere.redis.spring.metadata.SpringRedisMetadataRepository.isWrite;
 import static io.microsphere.redis.spring.metadata.SpringRedisMetadataRepository.isWriteCommandMethod;
 import static io.microsphere.redis.spring.metadata.SpringRedisMetadataRepository.redisCommandInterfacesCache;
@@ -64,10 +66,12 @@ import static io.microsphere.redis.spring.util.SpringRedisCommandUtils.REDIS_ZSE
 import static io.microsphere.redis.spring.util.SpringRedisCommandUtils.loadClass;
 import static io.microsphere.redis.util.RedisCommandUtils.buildMethodIndex;
 import static io.microsphere.redis.util.RedisCommandUtils.buildParameterMetadataList;
+import static io.microsphere.reflect.MethodUtils.findMethod;
 import static io.microsphere.util.ArrayUtils.EMPTY_STRING_ARRAY;
 import static io.microsphere.util.ArrayUtils.forEach;
 import static io.microsphere.util.IterableUtils.forEach;
 import static io.microsphere.util.StringUtils.EMPTY_STRING;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -180,7 +184,18 @@ class SpringRedisMetadataRepositoryTest {
 
     @Test
     void testCacheMethodInfoWithNull() {
-        cacheMethodInfo(null, null);
+        assertDoesNotThrow(() -> cacheMethodInfo(null, null));
+    }
+
+    @Test
+    void testInitRedisConnectionInterface() {
+        assertDoesNotThrow(() -> {
+            Method method = findMethod(String.class, "toUpperCase");
+            initRedisConnectionInterface(method);
+
+            Method method1 = findMethod(RedisCommandsExt.class, "set", byte[].class);
+            initRedisConnectionInterface(method1);
+        });
     }
 
     @Test
@@ -193,9 +208,11 @@ class SpringRedisMetadataRepositoryTest {
 
     @Test
     void testCache() {
-        Map<String, Object> map = newHashMap();
-        cache(map, "key", "value");
-        cache(map, "key", "value");
+        assertDoesNotThrow(() -> {
+            Map<String, Object> map = newHashMap();
+            cache(map, "key", "value");
+            cache(map, "key", "value");
+        });
     }
 
     void assertGetRedisCommandInterfaceClass(String interfaceName) {

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/SerializersTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/SerializersTest.java
@@ -46,6 +46,7 @@ import static io.microsphere.redis.spring.serializer.ShortSerializer.SHORT_SERIA
 import static io.microsphere.redis.spring.serializer.SortParametersSerializer.SORT_PARAMETERS_SERIALIZER;
 import static io.microsphere.util.ArrayUtils.EMPTY_BYTE_ARRAY;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -297,8 +298,10 @@ class SerializersTest {
 
     @Test
     void testRegister() {
-        register(String.class, DEFAULT_SERIALIZER);
-        register(String.class, STRING_SERIALIZER);
-        register(String.class, STRING_SERIALIZER);
+        assertDoesNotThrow(() -> {
+            register(String.class, DEFAULT_SERIALIZER);
+            register(String.class, STRING_SERIALIZER);
+            register(String.class, STRING_SERIALIZER);
+        });
     }
 }


### PR DESCRIPTION
This pull request focuses on improving code maintainability and robustness by refactoring property name construction for consistency and enhancing test reliability through better exception handling. The changes also add trace logging and minor code cleanups.

**Configuration and Property Name Refactoring:**

* Refactored property name construction in `RedisReplicatorConfiguration` to use the shared constant `ENABLED_PROPERTY_NAME` for both the main and consumer enabled property names, ensuring consistency and reducing duplication. [[1]](diffhunk://#diff-dba23f5e258e5b47cf8d9dc5793b2462dcc2d266ab429be4e6bbc0cc09ee5d75R40) [[2]](diffhunk://#diff-dba23f5e258e5b47cf8d9dc5793b2462dcc2d266ab429be4e6bbc0cc09ee5d75L74-R75) [[3]](diffhunk://#diff-dba23f5e258e5b47cf8d9dc5793b2462dcc2d266ab429be4e6bbc0cc09ee5d75L90-R91) [[4]](diffhunk://#diff-dba23f5e258e5b47cf8d9dc5793b2462dcc2d266ab429be4e6bbc0cc09ee5d75L235-R240)

**Testing Improvements:**

* Replaced direct exception-throwing test invocations with `assertDoesNotThrow` in multiple test classes to ensure that methods under test do not throw unexpected exceptions, making tests more robust and expressive. This applies to tests in `KafkaProducerRedisReplicatorConfigurationTest`, `RedisMethodInterceptorTest`, `SpringRedisMetadataLoaderTest`, `SpringRedisMetadataRepositoryTest`, and `SerializersTest`. [[1]](diffhunk://#diff-2807f55007f976ed213a73f67a38c9dca7f37d51e9b9a20ef223d0cbe250c17aL68-R73) [[2]](diffhunk://#diff-bf782b66fe0b9f7d06a9a509a0ab97d258dd9e6a5e4f1b1898b710c18232776fL76-R88) [[3]](diffhunk://#diff-4080ecd11b169c1d9eb17114e300be20131fb365a47446979bf55704a4a9866aR87) [[4]](diffhunk://#diff-4080ecd11b169c1d9eb17114e300be20131fb365a47446979bf55704a4a9866aR126) [[5]](diffhunk://#diff-12c30e2729ae998ef58beecc3882bad47d125566fcbac16c0c1146340a56c66eL183-R198) [[6]](diffhunk://#diff-12c30e2729ae998ef58beecc3882bad47d125566fcbac16c0c1146340a56c66eR211-R215) [[7]](diffhunk://#diff-7d6f796ddfa1bb55ae99ad7a8e5c4dad936c9c53d5f8ab663e4c4bbf7e9f3632R301-R305)

**Logging Enhancements:**

* Added a trace log statement in the `destroy` method of `KafkaRedisReplicatorConfiguration` to aid in debugging and lifecycle tracking.

**Test Utility Imports and Cleanups:**

* Added missing imports for `assertDoesNotThrow` and other utility methods across several test files to support the new test assertions. [[1]](diffhunk://#diff-2807f55007f976ed213a73f67a38c9dca7f37d51e9b9a20ef223d0cbe250c17aR30) [[2]](diffhunk://#diff-bf782b66fe0b9f7d06a9a509a0ab97d258dd9e6a5e4f1b1898b710c18232776fR36) [[3]](diffhunk://#diff-4080ecd11b169c1d9eb17114e300be20131fb365a47446979bf55704a4a9866aR42) [[4]](diffhunk://#diff-12c30e2729ae998ef58beecc3882bad47d125566fcbac16c0c1146340a56c66eR46) [[5]](diffhunk://#diff-12c30e2729ae998ef58beecc3882bad47d125566fcbac16c0c1146340a56c66eR69-R74) [[6]](diffhunk://#diff-7d6f796ddfa1bb55ae99ad7a8e5c4dad936c9c53d5f8ab663e4c4bbf7e9f3632R49)

**Additional Test Coverage:**

* Added new test cases for methods such as `initRedisConnectionInterface` in `SpringRedisMetadataRepositoryTest` to improve code coverage and ensure method reliability.

These changes collectively improve code clarity, maintainability, and test reliability.