### PR TITLE
Update pom.xml for release-1.x merge into dev-1.x

### DIFF
--- a/microsphere-redis-parent/pom.xml
+++ b/microsphere-redis-parent/pom.xml
@@ -21,7 +21,7 @@
     <properties>
         <spring-cloud-context.version>1.0.1.RELEASE</spring-cloud-context.version>
         <!-- BOM versions -->
-        <microsphere-spring-boot.version>0.1.8</microsphere-spring-boot.version>
+        <microsphere-spring-boot.version>0.1.10</microsphere-spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-boot-parent</artifactId>
-        <version>0.1.8</version>
+        <version>0.1.10</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request updates the project to use newer versions of the `microsphere-spring-boot` dependencies. These version bumps ensure compatibility with the latest features and fixes from the upstream libraries.

Dependency version updates:

* Updated the parent POM version in `pom.xml` from `0.1.8` to `0.1.10` to use the latest `microsphere-spring-boot-parent` release.
* Updated the `microsphere-spring-boot.version` property in `microsphere-redis-parent/pom.xml` from `0.1.8` to `0.1.10`.