### PR TITLE
Fix YAML indentation, update CI matrix, and bump branch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@
 
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+- package-ecosystem: "maven" # See documentation for possible values
+  directory: "/"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 10

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -20,10 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8' , '17' , '21' , '25' ]
-        maven-profile-spring-boot: [ 'spring-boot-2.1' , 'spring-boot-2.2' , 'spring-boot-2.3' ,
-                                     'spring-boot-2.4' , 'spring-boot-2.5' , 'spring-boot-2.6' ,
-                                     'spring-boot-2.7' ]
+        java: [ '8', '11' , '17' , '21' , '25' ]
+        maven-profile-spring-cloud: [ 'spring-cloud-hoxton' , 'spring-cloud-2020' , 'spring-cloud-2021' ]
     steps:
       - name: Docker Setup Compose
         uses: docker/setup-compose-action@v1.2.0

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -10,7 +10,7 @@ name: Maven Publish
 
 on:
   push:
-    branches: [ 'release' ]
+    branches: [ 'release-1.x' ]
   workflow_dispatch:
     inputs:
       revision:

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                     | **Latest Version** |
 |--------------|-------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Data Redis 3.0.0 - 3.5.x | 0.2.2              |
-| **0.1.x**    | Compatible with Spring Data Redis 2.1.0 - 2.7.x | 0.1.2              |
+| **0.2.x**    | Compatible with Spring Data Redis 3.0.0 - 3.5.x | 0.2.3              |
+| **0.1.x**    | Compatible with Spring Data Redis 2.1.0 - 2.7.x | 0.1.3              |
 
 Then add the specific modules you need:
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                     | **Latest Version** |
 |--------------|-------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Data Redis 3.0.0 - 3.5.x | 0.2.0              |
-| **0.1.x**    | Compatible with Spring Data Redis 2.1.0 - 2.7.x | 0.1.0              |
+| **0.2.x**    | Compatible with Spring Data Redis 3.0.0 - 3.5.x | 0.2.2              |
+| **0.1.x**    | Compatible with Spring Data Redis 2.1.0 - 2.7.x | 0.1.2              |
 
 Then add the specific modules you need:
 


### PR DESCRIPTION
This pull request updates the project's CI configuration and documentation to reflect recent changes in supported Java versions, Spring Cloud profiles, and published versions. The main focus is on aligning the build matrix with current support targets and keeping documentation up to date.

**CI/CD workflow updates:**

* Updated the build matrix in `.github/workflows/maven-build.yml` to add Java 11 to the supported versions and replace `maven-profile-spring-boot` with `maven-profile-spring-cloud` for the Spring Cloud profiles being tested.
* Changed the branch filter in `.github/workflows/maven-publish.yml` to trigger publishing only for the `release-1.x` branch instead of `release`.

**Documentation updates:**

* Updated the `README.md` to reflect the latest released versions for branches `0.2.x` and `0.1.x`.