### PR TITLE
Update microsphere-spring-cloud to 0.1.15 and enhance interceptors

### DIFF
--- a/microsphere-redis-core/src/main/java/io/microsphere/redis/metadata/MethodInfo.java
+++ b/microsphere-redis-core/src/main/java/io/microsphere/redis/metadata/MethodInfo.java
@@ -68,9 +68,9 @@ public class MethodInfo {
     /**
      * Constructs a {@link MethodInfo} from the given {@link Method}, {@link MethodMetadata}, and parameter metadata list.
      *
-     * @param method                 the reflected {@link Method}
-     * @param methodMetadata         the associated {@link MethodMetadata}
-     * @param parameterMetadataList  the list of {@link ParameterMetadata} for the method parameters
+     * @param method                the reflected {@link Method}
+     * @param methodMetadata        the associated {@link MethodMetadata}
+     * @param parameterMetadataList the list of {@link ParameterMetadata} for the method parameters
      */
     public MethodInfo(Method method, MethodMetadata methodMetadata, List<ParameterMetadata> parameterMetadataList) {
         this.id = buildMethodId(method);

--- a/microsphere-redis-core/src/main/java/io/microsphere/redis/util/RedisCommandUtils.java
+++ b/microsphere-redis-core/src/main/java/io/microsphere/redis/util/RedisCommandUtils.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.util;
 
-
 import io.microsphere.annotation.Immutable;
 import io.microsphere.annotation.Nonnull;
 import io.microsphere.lang.function.ThrowableFunction;
@@ -237,8 +236,8 @@ public abstract class RedisCommandUtils implements Utils {
     /**
      * Builds a method signature string using the method name and parameter class names.
      *
-     * @param methodName           the method name
-     * @param parameterClassNames  the parameter type class names (varargs)
+     * @param methodName          the method name
+     * @param parameterClassNames the parameter type class names (varargs)
      * @return non-null signature string, e.g. {@code "set([B,[B)"}
      */
     public static String buildMethodSignature(String methodName, String... parameterClassNames) {

--- a/microsphere-redis-core/src/main/java/io/microsphere/redis/util/RedisUtils.java
+++ b/microsphere-redis-core/src/main/java/io/microsphere/redis/util/RedisUtils.java
@@ -104,9 +104,9 @@ public abstract class RedisUtils {
      * passes the list of their {@link InputStream}s to {@code inputStreamsToTarget}, and returns the result.
      * All streams are closed after the function returns.
      *
-     * @param <T>                    the target type
-     * @param resourceName           the classpath resource path
-     * @param inputStreamsToTarget   function that converts a list of resource streams to {@code T}
+     * @param <T>                  the target type
+     * @param resourceName         the classpath resource path
+     * @param inputStreamsToTarget function that converts a list of resource streams to {@code T}
      * @return the converted result
      */
     public static <T> T loadResources(String resourceName, ThrowableFunction<List<InputStream>, T> inputStreamsToTarget) {
@@ -118,10 +118,10 @@ public abstract class RedisUtils {
      * passes the list of their {@link InputStream}s to {@code inputStreamsToTarget}, and returns the result.
      * All streams are closed after the function returns.
      *
-     * @param <T>                    the target type
-     * @param classLoader            the class loader to use for resource lookup
-     * @param resourceName           the classpath resource path
-     * @param inputStreamsToTarget   function that converts a list of resource streams to {@code T}
+     * @param <T>                  the target type
+     * @param classLoader          the class loader to use for resource lookup
+     * @param resourceName         the classpath resource path
+     * @param inputStreamsToTarget function that converts a list of resource streams to {@code T}
      * @return the converted result
      */
     public static <T> T loadResources(ClassLoader classLoader, String resourceName,

--- a/microsphere-redis-core/src/test/java/io/microsphere/redis/metadata/MethodInfoTest.java
+++ b/microsphere-redis-core/src/test/java/io/microsphere/redis/metadata/MethodInfoTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.metadata;
 
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/microsphere-redis-core/src/test/java/io/microsphere/redis/metadata/MethodMetadataTest.java
+++ b/microsphere-redis-core/src/test/java/io/microsphere/redis/metadata/MethodMetadataTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.metadata;
 
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/microsphere-redis-core/src/test/java/io/microsphere/redis/metadata/ParameterMetadataTest.java
+++ b/microsphere-redis-core/src/test/java/io/microsphere/redis/metadata/ParameterMetadataTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.metadata;
 
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/microsphere-redis-core/src/test/java/io/microsphere/redis/metadata/ParameterTest.java
+++ b/microsphere-redis-core/src/test/java/io/microsphere/redis/metadata/ParameterTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.metadata;
 
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/microsphere-redis-core/src/test/java/io/microsphere/redis/metadata/RedisMetadataLoaderTest.java
+++ b/microsphere-redis-core/src/test/java/io/microsphere/redis/metadata/RedisMetadataLoaderTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.metadata;
 
-
 import org.junit.jupiter.api.Test;
 
 import static io.microsphere.redis.metadata.RedisMetadataLoader.loadAll;

--- a/microsphere-redis-core/src/test/java/io/microsphere/redis/metadata/RedisMetadataTest.java
+++ b/microsphere-redis-core/src/test/java/io/microsphere/redis/metadata/RedisMetadataTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.metadata;
 
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/microsphere-redis-core/src/test/java/io/microsphere/redis/util/RawValueTest.java
+++ b/microsphere-redis-core/src/test/java/io/microsphere/redis/util/RawValueTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.util;
 
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/microsphere-redis-core/src/test/java/io/microsphere/redis/util/RedisCommandUtilsTest.java
+++ b/microsphere-redis-core/src/test/java/io/microsphere/redis/util/RedisCommandUtilsTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.util;
 
-
 import io.microsphere.redis.metadata.ParameterMetadata;
 import org.junit.jupiter.api.Test;
 

--- a/microsphere-redis-core/src/test/java/io/microsphere/redis/util/RedisUtilsTest.java
+++ b/microsphere-redis-core/src/test/java/io/microsphere/redis/util/RedisUtilsTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.util;
 
-
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;

--- a/microsphere-redis-parent/pom.xml
+++ b/microsphere-redis-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.14</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.15</microsphere-spring-cloud.version>
     </properties>
 
     <dependencyManagement>

--- a/microsphere-redis-parent/pom.xml
+++ b/microsphere-redis-parent/pom.xml
@@ -39,4 +39,5 @@
         </dependencies>
 
     </dependencyManagement>
+
 </project>

--- a/microsphere-redis-replicator-spring/src/main/java/io/microsphere/redis/replicator/spring/RedisCommandReplicator.java
+++ b/microsphere-redis-replicator-spring/src/main/java/io/microsphere/redis/replicator/spring/RedisCommandReplicator.java
@@ -16,7 +16,6 @@ import static io.microsphere.redis.spring.util.RedisSpringUtils.getRawRedisConne
 import static io.microsphere.reflect.AccessibleObjectUtils.trySetAccessible;
 import static org.springframework.util.ReflectionUtils.invokeMethod;
 
-
 /**
  * Redis Command Replicator
  *

--- a/microsphere-redis-replicator-spring/src/main/java/io/microsphere/redis/replicator/spring/RedisReplicatorInitializer.java
+++ b/microsphere-redis-replicator-spring/src/main/java/io/microsphere/redis/replicator/spring/RedisReplicatorInitializer.java
@@ -86,7 +86,6 @@ public class RedisReplicatorInitializer implements RedisModuleInitializer {
             }
         }
 
-
     }
 
     @Override

--- a/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/RedisCommandReplicatorTest.java
+++ b/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/RedisCommandReplicatorTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.replicator.spring;
 
-
 import io.microsphere.redis.replicator.spring.config.DefaultRedisConfig;
 import io.microsphere.redis.replicator.spring.event.RedisCommandReplicatedEvent;
 import io.microsphere.redis.spring.event.RedisCommandEvent;

--- a/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/RedisReplicatorInitializerTest.java
+++ b/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/RedisReplicatorInitializerTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.replicator.spring;
 
-
 import io.microsphere.redis.replicator.spring.config.FullRedisReplicationConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/config/RedisReplicatorConfigurationTest.java
+++ b/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/config/RedisReplicatorConfigurationTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.replicator.spring.config;
 
-
 import io.microsphere.redis.spring.config.RedisConfiguration;
 import io.microsphere.redis.spring.context.RedisContext;
 import io.microsphere.redis.spring.event.RedisConfigurationPropertyChangedEvent;

--- a/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/event/RedisCommandReplicatedEventTest.java
+++ b/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/event/RedisCommandReplicatedEventTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.replicator.spring.event;
 
-
 import io.microsphere.redis.spring.event.RedisCommandEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/kafka/KafkaRedisReplicatorConfigurationTest.java
+++ b/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/kafka/KafkaRedisReplicatorConfigurationTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.replicator.spring.kafka;
 
-
 import io.microsphere.redis.replicator.spring.config.FullRedisReplicationConfig;
 import io.microsphere.redis.replicator.spring.config.RedisReplicatorConfiguration;
 import org.junit.jupiter.api.AfterEach;

--- a/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/kafka/KafkaRedisReplicatorModuleInitializerTest.java
+++ b/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/kafka/KafkaRedisReplicatorModuleInitializerTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.replicator.spring.kafka;
 
-
 import io.microsphere.redis.replicator.spring.config.FullRedisReplicationConfig;
 import io.microsphere.redis.replicator.spring.kafka.consumer.KafkaConsumerRedisReplicatorConfiguration;
 import io.microsphere.redis.replicator.spring.kafka.producer.KafkaProducerRedisCommandEventListener;

--- a/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/kafka/consumer/KafkaConsumerRedisReplicatorConfigurationTest.java
+++ b/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/kafka/consumer/KafkaConsumerRedisReplicatorConfigurationTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.replicator.spring.kafka.consumer;
 
-
 import io.microsphere.redis.replicator.spring.config.FullRedisReplicationConfig;
 import io.microsphere.redis.replicator.spring.config.RedisReplicatorConfiguration;
 import io.microsphere.redis.replicator.spring.kafka.KafkaRedisReplicatorConfiguration;

--- a/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/kafka/producer/KafkaProducerRedisCommandEventListenerTest.java
+++ b/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/kafka/producer/KafkaProducerRedisCommandEventListenerTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.replicator.spring.kafka.producer;
 
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.kafka.support.SendResult;

--- a/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/kafka/producer/KafkaProducerRedisReplicatorConfigurationTest.java
+++ b/microsphere-redis-replicator-spring/src/test/java/io/microsphere/redis/replicator/spring/kafka/producer/KafkaProducerRedisReplicatorConfigurationTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.replicator.spring.kafka.producer;
 
-
 import io.microsphere.redis.replicator.spring.config.DefaultRedisReplicationConfig;
 import io.microsphere.redis.replicator.spring.config.FullRedisReplicationConfig;
 import io.microsphere.redis.replicator.spring.config.RedisReplicatorConfiguration;

--- a/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/annotation/EnableRedisInterceptor.java
+++ b/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/annotation/EnableRedisInterceptor.java
@@ -19,7 +19,10 @@ package io.microsphere.redis.spring.annotation;
 import io.microsphere.redis.spring.beans.RedisTemplateWrapper;
 import io.microsphere.redis.spring.beans.StringRedisTemplateWrapper;
 import io.microsphere.redis.spring.event.RedisCommandEvent;
+import io.microsphere.redis.spring.interceptor.RedisCommandInterceptor;
+import io.microsphere.redis.spring.interceptor.RedisConnectionInterceptor;
 import io.microsphere.redis.spring.util.RedisConstants;
+import io.microsphere.spring.beans.BeanSource;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 
@@ -28,6 +31,9 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import static io.microsphere.spring.beans.BeanSource.BEAN_FACTORY;
+import static io.microsphere.spring.beans.BeanSource.SPRING_FACTORIES;
 
 /**
  * Meta-annotation that activates the Redis interceptor infrastructure, enabling transparent
@@ -93,5 +99,16 @@ public @interface EnableRedisInterceptor {
      * @return If {@link RedisCommandEvent} is required to be exposed, return <code>true</code>, or <code>false</code>
      */
     boolean exposeCommandEvent() default true;
+
+    /**
+     * The sources that will be used to register the beans of Interceptor, such as:
+     * <ul>
+     *     <li>{@link RedisCommandInterceptor}</li>
+     *     <li>{@link RedisConnectionInterceptor}</li>
+     * </ul>
+     *
+     * @return default is {@link BeanSource#BEAN_FACTORY} and {@link BeanSource#SPRING_FACTORIES}
+     */
+    BeanSource[] sources() default {BEAN_FACTORY, SPRING_FACTORIES};
 
 }

--- a/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/annotation/RedisInterceptorBeanDefinitionRegistrar.java
+++ b/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/annotation/RedisInterceptorBeanDefinitionRegistrar.java
@@ -21,26 +21,25 @@ import io.microsphere.redis.spring.beans.RedisConnectionFactoryProxyBeanPostProc
 import io.microsphere.redis.spring.beans.RedisTemplateWrapperBeanPostProcessor;
 import io.microsphere.redis.spring.beans.WrapperProcessors;
 import io.microsphere.redis.spring.interceptor.EventPublishingRedisCommandInterceptor;
+import io.microsphere.redis.spring.interceptor.RedisCommandInterceptor;
+import io.microsphere.redis.spring.interceptor.RedisConnectionInterceptor;
+import io.microsphere.spring.beans.BeanSource;
+import io.microsphere.spring.context.annotation.BeanCapableImportCandidate;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.core.annotation.AnnotationAttributes;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
 
+import java.util.Map;
 import java.util.Set;
 
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.redis.spring.interceptor.EventPublishingRedisCommandInterceptor.BEAN_NAME;
 import static io.microsphere.redis.spring.util.RedisSpringUtils.getWrappedRedisTemplateBeanNames;
+import static io.microsphere.spring.beans.BeanSource.registerBeans;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asConfigurableBeanFactory;
-import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asConfigurableListableBeanFactory;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
-import static io.microsphere.spring.core.annotation.AnnotationUtils.getAnnotationAttributes;
-import static io.microsphere.spring.core.env.EnvironmentUtils.asConfigurableEnvironment;
 import static org.springframework.util.CollectionUtils.isEmpty;
 
 /**
@@ -73,27 +72,22 @@ import static org.springframework.util.CollectionUtils.isEmpty;
  * @see EnableRedisInterceptor
  * @since 1.0.0
  */
-class RedisInterceptorBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware {
-
-    private static Class<EnableRedisInterceptor> ENABLE_REDIS_INTERCEPTOR_CLASS = EnableRedisInterceptor.class;
+class RedisInterceptorBeanDefinitionRegistrar extends BeanCapableImportCandidate implements ImportBeanDefinitionRegistrar {
 
     private static final Logger logger = getLogger(RedisInterceptorBeanDefinitionRegistrar.class);
 
-    private ConfigurableEnvironment environment;
-
     @Override
-    public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
-        AnnotationAttributes annotationAttributes = getAnnotationAttributes(importingClassMetadata, ENABLE_REDIS_INTERCEPTOR_CLASS);
-        String[] wrapRedisTemplates = annotationAttributes.getStringArray("wrapRedisTemplates");
-        boolean exposeCommandEvent = annotationAttributes.getBoolean("exposeCommandEvent");
+    public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
+        ResolvablePlaceholderAnnotationAttributes<EnableRedisInterceptor> attributes = getAnnotationAttributes(metadata, EnableRedisInterceptor.class);
+        String[] wrapRedisTemplates = attributes.getStringArray("wrapRedisTemplates");
+        boolean exposeCommandEvent = attributes.getBoolean("exposeCommandEvent");
+        BeanSource[] sources = (BeanSource[]) attributes.get("sources");
 
-        logger.trace("@EnableRedisInterceptor({}} annotated on the '{}'", annotationAttributes, importingClassMetadata);
+        logger.trace("@EnableRedisInterceptor({}} annotated on the '{}'", attributes, metadata);
 
-        ConfigurableListableBeanFactory beanFactory = asConfigurableListableBeanFactory(registry);
+        Set<String> wrapRedisTemplateBeanNames = getWrappedRedisTemplateBeanNames(this.beanFactory, this.environment, wrapRedisTemplates);
 
-        Set<String> wrapRedisTemplateBeanNames = getWrappedRedisTemplateBeanNames(beanFactory, this.environment, wrapRedisTemplates);
-
-        registerBeanDefinitions(wrapRedisTemplateBeanNames, exposeCommandEvent, registry);
+        registerBeanDefinitions(wrapRedisTemplateBeanNames, exposeCommandEvent, sources, registry);
     }
 
     /**
@@ -103,10 +97,12 @@ class RedisInterceptorBeanDefinitionRegistrar implements ImportBeanDefinitionReg
      * @param wrappedRedisTemplateBeanNames the resolved set of {@link org.springframework.data.redis.core.RedisTemplate}
      *                                      bean names to wrap; may be empty
      * @param exposedCommandEvent           {@code true} to register the
-     *                                      {@link io.microsphere.redis.spring.interceptor.EventPublishingRedisCommandInterceptor}
+     *                                      {@link EventPublishingRedisCommandInterceptor}
+     * @param sources                       the sources that will be used to register the beans of Interceptor
      * @param registry                      the Spring bean-definition registry to register beans into
      */
-    public void registerBeanDefinitions(Set<String> wrappedRedisTemplateBeanNames, boolean exposedCommandEvent, BeanDefinitionRegistry registry) {
+    public void registerBeanDefinitions(Set<String> wrappedRedisTemplateBeanNames, boolean exposedCommandEvent,
+                                        BeanSource[] sources, BeanDefinitionRegistry registry) {
 
         if (isEmpty(wrappedRedisTemplateBeanNames)) {
             addRedisConnectionFactoryProxyBeanPostProcessor(registry);
@@ -119,6 +115,8 @@ class RedisInterceptorBeanDefinitionRegistrar implements ImportBeanDefinitionReg
         if (exposedCommandEvent) {
             registerEventPublishingRedisCommendInterceptor(registry);
         }
+
+        registerInterceptors(sources);
     }
 
     private void registerRedisTemplateWrapperBeanPostProcessor(Set<String> wrappedRedisTemplateBeanNames, BeanDefinitionRegistry registry) {
@@ -130,16 +128,18 @@ class RedisInterceptorBeanDefinitionRegistrar implements ImportBeanDefinitionReg
         beanFactory.addBeanPostProcessor(new RedisConnectionFactoryProxyBeanPostProcessor(beanFactory));
     }
 
-    private void registerEventPublishingRedisCommendInterceptor(BeanDefinitionRegistry registry) {
-        registerBeanDefinition(registry, BEAN_NAME, EventPublishingRedisCommandInterceptor.class);
-    }
-
     private void registerWrapperProcessors(BeanDefinitionRegistry registry) {
         registerBeanDefinition(registry, WrapperProcessors.BEAN_NAME, WrapperProcessors.class);
     }
 
-    @Override
-    public void setEnvironment(Environment environment) {
-        this.environment = asConfigurableEnvironment(environment);
+    private void registerEventPublishingRedisCommendInterceptor(BeanDefinitionRegistry registry) {
+        registerBeanDefinition(registry, BEAN_NAME, EventPublishingRedisCommandInterceptor.class);
+    }
+
+    private void registerInterceptors(BeanSource[] sources) {
+        Map<Class<?>, String> beanTypesAndNames = registerBeans(this.beanFactory, sources,
+                RedisCommandInterceptor.class,
+                RedisConnectionInterceptor.class);
+        logger.trace("Registered Redis interceptors , sources : {} , beans : {}", sources, beanTypesAndNames);
     }
 }

--- a/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/beans/StringRedisTemplateWrapper.java
+++ b/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/beans/StringRedisTemplateWrapper.java
@@ -8,7 +8,6 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import static io.microsphere.redis.spring.beans.RedisConnectionFactoryProxyBeanPostProcessor.newProxyRedisConnection;
 import static io.microsphere.redis.spring.beans.RedisTemplateWrapper.configure;
 
-
 /**
  * A transparent {@link StringRedisTemplate} subclass that intercepts every Redis connection by wrapping
  * it in a JDK-proxy created by

--- a/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/event/RedisCommandEvent.java
+++ b/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/event/RedisCommandEvent.java
@@ -31,7 +31,6 @@ import static io.microsphere.redis.spring.serializer.RedisCommandEventSerializer
 import static io.microsphere.redis.spring.serializer.RedisCommandEventSerializer.VERSION_V1;
 import static io.microsphere.util.ArrayUtils.arrayToString;
 
-
 /**
  * Spring {@link ApplicationEvent} that captures a single Redis command invocation together with
  * its method, arguments, source bean name, and application name.  Published by

--- a/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/serializer/Serializers.java
+++ b/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/serializer/Serializers.java
@@ -214,7 +214,7 @@ public abstract class Serializers {
      *
      * @param parameter the parameter whose value should be serialized; may be {@code null}
      * @return the serialized bytes, or {@code null} if {@code parameter} is {@code null} or
-     *         serialization produced no output
+     * serialization produced no output
      */
     @Nullable
     public static byte[] serializeRawParameter(Parameter parameter) {
@@ -262,7 +262,7 @@ public abstract class Serializers {
      *
      * @param object the object to serialize; may be {@code null}
      * @return the serialized bytes, or {@code null} if {@code object} is {@code null} or
-     *         no serializer is found
+     * no serializer is found
      */
     @Nullable
     public static byte[] serialize(Object object) {
@@ -493,6 +493,7 @@ public abstract class Serializers {
     private static List<RedisSerializer> loadSerializers() {
         return loadFactories(RedisSerializer.class, classLoader);
     }
+
     static void register(Class<?> type, RedisSerializer<?> serializer) {
         String typeName = type.getName();
         doRegister(typeName, serializer);

--- a/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/util/RedisSpringUtils.java
+++ b/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/util/RedisSpringUtils.java
@@ -278,11 +278,11 @@ public abstract class RedisSpringUtils implements Utils {
      * Reads a boolean configuration property from the Spring {@link Environment}, logs the
      * resolved value, and returns it.
      *
-     * @param environment   the Spring environment
-     * @param propertyName  the property name to look up (e.g. {@code "microsphere.redis.enabled"})
-     * @param defaultValue  the value to use when the property is not set
-     * @param feature       a human-readable feature label used in the log message (e.g. {@code "Configuration"})
-     * @param statusIfTrue  the label used in the log message when the value is {@code true} (e.g. {@code "enabled"})
+     * @param environment  the Spring environment
+     * @param propertyName the property name to look up (e.g. {@code "microsphere.redis.enabled"})
+     * @param defaultValue the value to use when the property is not set
+     * @param feature      a human-readable feature label used in the log message (e.g. {@code "Configuration"})
+     * @param statusIfTrue the label used in the log message when the value is {@code true} (e.g. {@code "enabled"})
      * @return the resolved boolean value
      */
     public static boolean getBoolean(Environment environment, String propertyName, boolean defaultValue, String feature, String statusIfTrue) {

--- a/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/util/SpringRedisCommandUtils.java
+++ b/microsphere-redis-spring/src/main/java/io/microsphere/redis/spring/util/SpringRedisCommandUtils.java
@@ -371,7 +371,7 @@ public abstract class SpringRedisCommandUtils {
      *
      * @param classNames the fully-qualified class names to load
      * @return array of loaded {@link Class} objects; elements may be {@code null} if the class
-     *         could not be found
+     * could not be found
      */
     public static Class<?>[] loadClasses(String... classNames) {
         int length = classNames.length;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/annotation/EnableRedisInterceptorTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/annotation/EnableRedisInterceptorTest.java
@@ -18,10 +18,12 @@ package io.microsphere.redis.spring.annotation;
 
 import io.microsphere.redis.spring.AbstractRedisCommandEventTest;
 import io.microsphere.redis.spring.interceptor.LoggingRedisCommandInterceptor;
-import io.microsphere.redis.spring.interceptor.StopWatchRedisConnectionInterceptor;
-import io.microsphere.redis.spring.interceptor.ThrowingExceptionRedisCommandInterceptor;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
+
+import static io.microsphere.spring.beans.BeanSource.BEAN_FACTORY;
+import static io.microsphere.spring.beans.BeanSource.JAVA_SERVICE_PROVIDER;
+import static io.microsphere.spring.beans.BeanSource.SPRING_FACTORIES;
 
 /**
  * {@link EnableRedisInterceptor} Test
@@ -30,8 +32,6 @@ import org.springframework.test.context.TestPropertySource;
  * @since 1.0.0
  */
 @ContextConfiguration(classes = {
-        StopWatchRedisConnectionInterceptor.class,
-        ThrowingExceptionRedisCommandInterceptor.class,
         LoggingRedisCommandInterceptor.class,
         EnableRedisInterceptorTest.class
 })
@@ -42,6 +42,10 @@ import org.springframework.test.context.TestPropertySource;
 @EnableRedisInterceptor(wrapRedisTemplates = {
         "${microsphere.redis.wrapped-rest-templates}",
         " redisTemplate , stringRedisTemplate"
+}, sources = {
+        BEAN_FACTORY,
+        SPRING_FACTORIES,
+        JAVA_SERVICE_PROVIDER
 })
 class EnableRedisInterceptorTest extends AbstractRedisCommandEventTest {
 }

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/annotation/RedisConfigurationBeanDefinitionRegistrarTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/annotation/RedisConfigurationBeanDefinitionRegistrarTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.annotation;
 
-
 import io.microsphere.redis.spring.config.RedisConfiguration;
 import io.microsphere.redis.spring.event.PropagatingRedisConfigurationPropertyChangedEventApplicationListener;
 import org.junit.jupiter.api.Test;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/annotation/RedisInterceptorBeanDefinitionRegistrarTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/annotation/RedisInterceptorBeanDefinitionRegistrarTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.annotation;
 
-
 import io.microsphere.redis.spring.beans.RedisTemplateWrapperBeanPostProcessor;
 import io.microsphere.redis.spring.beans.WrapperProcessors;
 import io.microsphere.redis.spring.interceptor.EventPublishingRedisCommandInterceptor;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/beans/RedisConnectionFactoryProxyBeanPostProcessorTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/beans/RedisConnectionFactoryProxyBeanPostProcessorTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.beans;
 
-
 import io.microsphere.redis.spring.AbstractRedisTest;
 import io.microsphere.redis.spring.config.RedisContextConfig;
 import org.junit.jupiter.api.Test;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/beans/RedisTemplateWrapperBeanPostProcessorTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/beans/RedisTemplateWrapperBeanPostProcessorTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.beans;
 
-
 import io.microsphere.redis.spring.config.RedisContextConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/beans/RedisTemplateWrapperTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/beans/RedisTemplateWrapperTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.beans;
 
-
 import io.microsphere.redis.spring.config.RedisContextConfig;
 import io.microsphere.redis.spring.context.RedisContext;
 import org.junit.jupiter.api.BeforeEach;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/beans/StringRedisTemplateWrapperTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/beans/StringRedisTemplateWrapperTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.beans;
 
-
 import io.microsphere.redis.spring.config.RedisContextConfig;
 import io.microsphere.redis.spring.context.RedisContext;
 import org.junit.jupiter.api.BeforeEach;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/config/RedisConfigurationTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/config/RedisConfigurationTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.config;
 
-
 import io.microsphere.redis.spring.AbstractRedisTest;
 import io.microsphere.redis.spring.event.RedisConfigurationPropertyChangedEvent;
 import org.junit.jupiter.api.Test;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/connection/dynamic/DynamicRedisConnectionFactoryTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/connection/dynamic/DynamicRedisConnectionFactoryTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.connection.dynamic;
 
-
 import io.microsphere.redis.spring.AbstractRedisTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,7 +55,6 @@ class DynamicRedisConnectionFactoryTest extends AbstractRedisTest {
     private static final String REDIS_CONNECTION_FACTORY_BEAN_NAME = "redisConnectionFactory";
 
     private static final String MOCK_REDIS_CONNECTION_FACTORY_BEAN_NAME = "mockRedisConnectionFactory";
-
 
     @Bean
     @Primary

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/connection/dynamic/web/DynamicRedisConnectionFactoryCleanerListenerTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/connection/dynamic/web/DynamicRedisConnectionFactoryCleanerListenerTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.connection.dynamic.web;
 
-
 import org.junit.jupiter.api.Test;
 
 import static io.microsphere.redis.spring.connection.dynamic.DynamicRedisConnectionFactory.DEFAULT_REDIS_CONNECTION_FACTORY_BEAN_NAME;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/context/RedisContextTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/context/RedisContextTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.context;
 
-
 import io.microsphere.redis.spring.AbstractRedisTest;
 import io.microsphere.redis.spring.config.RedisConfiguration;
 import io.microsphere.redis.spring.config.RedisContextConfig;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/context/RedisInitializerTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/context/RedisInitializerTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.context;
 
-
 import io.microsphere.redis.spring.config.RedisContextConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/event/PropagatingRedisConfigurationPropertyChangedEventApplicationListenerTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/event/PropagatingRedisConfigurationPropertyChangedEventApplicationListenerTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.event;
 
-
 import io.microsphere.redis.spring.config.RedisContextConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/event/RedisCommandEventTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/event/RedisCommandEventTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.event;
 
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.connection.RedisCommands;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/event/RedisConfigurationPropertyChangedEventTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/event/RedisConfigurationPropertyChangedEventTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.event;
 
-
 import io.microsphere.redis.spring.config.RedisConfiguration;
 import io.microsphere.redis.spring.config.RedisContextConfig;
 import org.junit.jupiter.api.Test;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/event/RedisOperationEventTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/event/RedisOperationEventTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.event;
 
-
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEvent;
 

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/interceptor/EventPublishingRedisCommandInterceptorTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/interceptor/EventPublishingRedisCommandInterceptorTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.interceptor;
 
-
 import io.microsphere.redis.spring.AbstractRedisTest;
 import io.microsphere.redis.spring.config.RedisContextConfig;
 import io.microsphere.redis.spring.context.RedisContext;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/interceptor/LoggingRedisConnectionInterceptor.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/interceptor/LoggingRedisConnectionInterceptor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.redis.spring.interceptor;
+
+import io.microsphere.logging.Logger;
+import org.springframework.data.redis.connection.RedisConnection;
+
+import static io.microsphere.logging.LoggerFactory.getLogger;
+
+/**
+ * {@link RedisConnectionInterceptor} for logging
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see RedisConnectionInterceptor
+ * @since 1.0.0
+ */
+public class LoggingRedisConnectionInterceptor implements RedisConnectionInterceptor {
+
+    private static final Logger logger = getLogger(LoggingRedisConnectionInterceptor.class);
+
+    @Override
+    public void beforeExecute(RedisMethodContext context) throws Throwable {
+        logger.info("beforeExecute - context: {}", context);
+    }
+
+    @Override
+    public void afterExecute(RedisMethodContext<RedisConnection> context, Object result, Throwable failure) throws Throwable {
+        logger.info("afterExecute - context: {} , result: {}", context, result, failure);
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+}

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/interceptor/RedisMethodInterceptorTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/interceptor/RedisMethodInterceptorTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.interceptor;
 
-
 import io.microsphere.redis.spring.AbstractRedisTest;
 import io.microsphere.redis.spring.config.RedisContextConfig;
 import io.microsphere.redis.spring.context.RedisContext;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/interceptor/StopWatchRedisConnectionInterceptor.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/interceptor/StopWatchRedisConnectionInterceptor.java
@@ -36,7 +36,6 @@ public class StopWatchRedisConnectionInterceptor implements RedisConnectionInter
         context.start();
     }
 
-
     @Override
     public void afterExecute(RedisMethodContext<RedisConnection> context, Object result, Throwable failure) throws Throwable {
         context.stop();

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/metadata/SpringRedisMetadataLoaderTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/metadata/SpringRedisMetadataLoaderTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.metadata;
 
-
 import io.microsphere.logging.Logger;
 import io.microsphere.redis.metadata.MethodMetadata;
 import io.microsphere.redis.metadata.RedisMetadata;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/metadata/SpringRedisMetadataRepositoryTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/metadata/SpringRedisMetadataRepositoryTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.metadata;
 
-
 import io.microsphere.redis.metadata.MethodInfo;
 import io.microsphere.redis.metadata.MethodMetadata;
 import io.microsphere.redis.util.RedisCommandUtils;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/BoundarySerializerTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/BoundarySerializerTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.serializer;
 
-
 import org.springframework.data.redis.connection.RedisZSetCommands.Range.Boundary;
 import org.springframework.data.redis.serializer.RedisSerializer;
 

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/ByteArraySerializerTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/ByteArraySerializerTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.serializer;
 
-
 import org.springframework.data.redis.serializer.RedisSerializer;
 
 import static io.microsphere.redis.spring.serializer.ByteArraySerializer.BYTE_ARRAY_SERIALIZER;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/EnumSerializerTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/EnumSerializerTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.serializer;
 
-
 import io.microsphere.spring.core.SpringVersion;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.serializer.RedisSerializer;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/HoldingValueRedisSerializerWrapperTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/HoldingValueRedisSerializerWrapperTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.serializer;
 
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.core.RedisTemplate;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/RangeSerializerTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/RangeSerializerTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.serializer;
 
-
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.serializer.RedisSerializer;
 

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/RedisCommandEventSerializerTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/RedisCommandEventSerializerTest.java
@@ -28,7 +28,6 @@ import static io.microsphere.redis.spring.serializer.RedisCommandEventSerializer
 import static io.microsphere.redis.spring.serializer.RedisCommandEventSerializer.VERSION_V1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
 /**
  * {@link RedisCommandEventSerializer} Test
  *

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/RedisZSetCommandsRangeSerializerTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/serializer/RedisZSetCommandsRangeSerializerTest.java
@@ -1,6 +1,5 @@
 package io.microsphere.redis.spring.serializer;
 
-
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.connection.RedisZSetCommands;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range.Boundary;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/util/RedisConstantsTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/util/RedisConstantsTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.util;
 
-
 import org.junit.jupiter.api.Test;
 
 import static io.microsphere.collection.Sets.ofSet;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/util/RedisSpringUtilsTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/util/RedisSpringUtilsTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.util;
 
-
 import io.microsphere.redis.spring.annotation.EnableRedisInterceptor;
 import io.microsphere.redis.spring.config.RedisConfig;
 import io.microsphere.redis.spring.config.RedisContextConfig;

--- a/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/util/SpringRedisCommandUtilsTest.java
+++ b/microsphere-redis-spring/src/test/java/io/microsphere/redis/spring/util/SpringRedisCommandUtilsTest.java
@@ -17,7 +17,6 @@
 
 package io.microsphere.redis.spring.util;
 
-
 import io.microsphere.redis.metadata.ParameterMetadata;
 import io.microsphere.redis.spring.config.RedisConfig;
 import io.microsphere.redis.spring.config.RedisContextConfig;

--- a/microsphere-redis-spring/src/test/resources/META-INF/services/io.microsphere.redis.spring.interceptor.RedisCommandInterceptor
+++ b/microsphere-redis-spring/src/test/resources/META-INF/services/io.microsphere.redis.spring.interceptor.RedisCommandInterceptor
@@ -1,0 +1,1 @@
+io.microsphere.redis.spring.interceptor.ThrowingExceptionRedisCommandInterceptor

--- a/microsphere-redis-spring/src/test/resources/META-INF/services/io.microsphere.redis.spring.interceptor.RedisConnectionInterceptor
+++ b/microsphere-redis-spring/src/test/resources/META-INF/services/io.microsphere.redis.spring.interceptor.RedisConnectionInterceptor
@@ -1,0 +1,1 @@
+io.microsphere.redis.spring.interceptor.LoggingRedisConnectionInterceptor

--- a/microsphere-redis-spring/src/test/resources/META-INF/spring.factories
+++ b/microsphere-redis-spring/src/test/resources/META-INF/spring.factories
@@ -1,2 +1,5 @@
 org.springframework.context.ApplicationContextInitializer=\
 io.microsphere.redis.spring.context.RedisInterceptorModuleInitializer
+
+io.microsphere.redis.spring.interceptor.RedisConnectionInterceptor=\
+io.microsphere.redis.spring.interceptor.StopWatchRedisConnectionInterceptor

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.14</version>
+        <version>0.1.15</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request primarily contains minor code cleanups and dependency updates. The most significant change is the update of the `microsphere-spring-cloud` dependency version in the parent POM. Additionally, several files had unused blank lines removed to improve code readability.

Dependency management:

* Updated the `microsphere-spring-cloud.version` property from `0.1.14` to `0.1.15` in `microsphere-redis-parent/pom.xml`, ensuring the project uses the latest compatible version.

Code cleanup and formatting:

* Removed unnecessary blank lines after package declarations and before imports in various test and main source files to improve code style and maintain consistency. [[1]](diffhunk://#diff-5308c83aaf7488dfde4635076511448bb0cd2fa6456f8ca6657c3db559ae4a12L20) [[2]](diffhunk://#diff-4212c6a853ba61e2abf5a6b11dc1fb50606321c8bc532aab46b2073856e3aa51L20) [[3]](diffhunk://#diff-451c60f3a5050e41f4533ca4f43eeee07d215061c8dcde737fe54aca46db0d66L20) [[4]](diffhunk://#diff-b0fd31d4d997f108d9b2d65e43c64b9ee54152fdb27242045058743e46762823L20) [[5]](diffhunk://#diff-4629b288dfe2f7409093df5f0b8e81c7764eca76f24c8f52a44c33cd5ca43fbeL20) [[6]](diffhunk://#diff-638ca6132e7e77f1ba001ebfa7dbf81f0ea13c54a550239a7049bec59a2e42d7L20) [[7]](diffhunk://#diff-d4dda482dfae8ee32407f140ec295fa1557a9798941def9972580af196524330L20) [[8]](diffhunk://#diff-238a0b2c6ff62ae7938de66a7fcc9bd57be376502d63bcb4030494d8e9794a48L20) [[9]](diffhunk://#diff-74af28f625739114aca4bb8723375a91921c05754e83ecc0daeb88fe3c16fa2cL20) [[10]](diffhunk://#diff-392ac0f1158a53624a8310ef1cc55f930f8414fdaa310563fe79d2bba846f586L20) [[11]](diffhunk://#diff-4f575e6b3024f56cdaccd711e13b8efdc1d42820d05d7f9c2c7858d3c207ef1cL19) [[12]](diffhunk://#diff-8b90699b6ffd1d370ddabc9d348a3b0d85436325ce38bc928fb91b7807cee0bcL20) [[13]](diffhunk://#diff-6839c406514910220f7118d7a1c1687bb1fe8bcbbc553c506063a9e05f88aa39L20) [[14]](diffhunk://#diff-2aaee9662962d221a3e3c86d591d474fc7f30c4f9aa2fd27a2ffa047c6ea0cf2L20) [[15]](diffhunk://#diff-28ce8f994cc5fce52e88bf15b4600d2aa9272ec1ded277a1d8227132847efdd7L20) [[16]](diffhunk://#diff-8a5c08fd342bbb53c9f678d6e909a19d89fa88e9eb178f5adeb3b4c22ce00405L20)
* Removed an unnecessary blank line in the `initializeRedisReplicatorModuleInitializers` method in `RedisReplicatorInitializer.java`.
* Removed an extra blank line at the end of `microsphere-redis-parent/pom.xml`.