### PR TITLE
Update microsphere-spring-cloud version and README branch info

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                     | **Latest Version** |
 |--------------|-------------------------------------------------|--------------------|
-| **main**     | Compatible with Spring Data Redis 3.0.0 - 3.5.x | `0.2.6`            |
-| **1.x**      | Compatible with Spring Data Redis 2.1.0 - 2.7.x | `0.1.6`            |
+| **main**     | Compatible with Spring Data Redis 3.0.0 - 3.5.x | `0.2.8`            |
+| **1.x**      | Compatible with Spring Data Redis 2.1.0 - 2.7.x | `0.1.8`            |
 
 Then add the specific modules you need:
 

--- a/microsphere-redis-parent/pom.xml
+++ b/microsphere-redis-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.15</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.16</microsphere-spring-cloud.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.15</version>
+        <version>0.1.16</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request updates version numbers for dependencies and documentation to ensure compatibility with the latest releases. The main focus is on keeping the project aligned with recent versions of Spring Data Redis and the Microsphere Spring Cloud BOM.

Dependency and parent version updates:

* Updated the parent project version in `pom.xml` from `0.1.15` to `0.1.16` to use the latest `microsphere-spring-cloud-parent`.
* Updated the `microsphere-spring-cloud.version` property in `microsphere-redis-parent/pom.xml` from `0.1.15` to `0.1.16`.

Documentation updates:

* Updated the latest version numbers for the `main` and `1.x` branches in the version compatibility table in `README.md` (`0.2.6` → `0.2.8` for `main`, `0.1.6` → `0.1.8` for `1.x`).